### PR TITLE
The authorized_keys module now works from URLs.

### DIFF
--- a/roles/common/tasks/accounts.yml
+++ b/roles/common/tasks/accounts.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: directory to hold public keys
-  file: state=directory path=/tmp/pubkeys mode=0755
-
-- name: fetch public keys from github
-  get_url: dest=/tmp/pubkeys/{{ item }}-pubkeys url=https://github.com/{{ item }}.keys
+- name: trust GitHub users
+  authorized_key: user=core state=present key=https://github.com/{{ item }}.keys
   with_items: github_usernames
-
-- name: assemble the authorized keys file
-  assemble: dest=/home/core/.ssh/authorized_keys mode=0600 src=/tmp/pubkeys


### PR DESCRIPTION
This simplifies `accounts.yml` quite a bit.
