### PR TITLE
Update the content-service configuration variables.

### DIFF
--- a/customize.example.yml
+++ b/customize.example.yml
@@ -8,8 +8,10 @@ control_repository_url: https://github.com/deconst/map-example.git
 # Branch of the control repository that governs this deployment.
 control_repository_branch: master
 
-# Cloud Files container used to store raw content as metadata envelopes.
+# Cloud Files containers used to store raw content as metadata envelopes and to
+# store CDN-distributed, fingerprinted assets.
 content_container: deconst-docs
+asset_container: deconst-assets
 
 # Optionally override the domain of presented URLs.
 presented_url_domain:

--- a/roles/content/tasks/main.yml
+++ b/roles/content/tasks/main.yml
@@ -10,7 +10,8 @@
       RACKSPACE_USERNAME: "{{ rackspace_username }}"
       RACKSPACE_APIKEY: "{{ rackspace_api_key }}"
       RACKSPACE_REGION: "{{ rackspace_region }}"
-      RACKSPACE_CONTAINER: "{{ content_container }}"
+      CONTENT_CONTAINER: "{{ content_container }}"
+      ASSET_CONTAINER: "{{ asset_container }}"
       CONTENT_LOG_LEVEL: "{{ content_log_level }}"
     ports:
     - "{{ content_service_port }}:8080"


### PR DESCRIPTION
Rather than a single `RACKSPACE_CONTAINER`, the content service now accepts `CONTENT_CONTAINER` and `ASSET_CONTAINER`.

Related to deconst/content-service#13 and deconst/deconst-docs#13.
