### PR TITLE
API key

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -14,3 +14,8 @@ build_admin_password:
 
 # MongoDB URI
 mongodb_uri:
+
+# Choose an administrative API key for the content service.
+# For example:
+#  hexdump -v -e '1/1 "%.2x"' -n 128 /dev/random
+content_admin_apikey:

--- a/roles/content/tasks/main.yml
+++ b/roles/content/tasks/main.yml
@@ -10,6 +10,7 @@
       RACKSPACE_USERNAME: "{{ rackspace_username }}"
       RACKSPACE_APIKEY: "{{ rackspace_api_key }}"
       RACKSPACE_REGION: "{{ rackspace_region }}"
+      ADMIN_APIKEY: "{{ content_admin_apikey }}"
       CONTENT_CONTAINER: "{{ content_container }}"
       ASSET_CONTAINER: "{{ asset_container }}"
       CONTENT_LOG_LEVEL: "{{ content_log_level }}"


### PR DESCRIPTION
Configure the content service to launch with an admin API key.

Part of deconst/deconst-docs#15.
