### PR TITLE
Automatically create webhooks

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -79,6 +79,12 @@ mongodb_uri: "mongodb://{{ mongodb_username }}:{{ mongodb_password }}@{{ mongodb
 # GitHub access token used to validate received webhook payloads.
 control_repository_token:
 
+# GitHub OAuth token used to manage webhooks.
+#
+# Generate a unique token for this at: https://github.com/settings/tokens/new
+github_oauth_user:
+github_oauth_token:
+
 # Choose a secure administrative API key for the content service.
 # For example:
 #  hexdump -v -e '1/1 "%.2x"' -n 128 /dev/random

--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -7,8 +7,14 @@
 # hosts, granting them access.
 github_usernames: []
 
-# URL of the GitHub repository containing the site mapping and layouts.
-control_repository_url: https://github.com/deconst/control-example.git
+# Name and URL of the GitHub repository containing the site mapping and layouts.
+#
+# `control_repository_name` should be used if the control repository is hosted on GitHub. If it
+# is, the control repository webhooks will be automatically created by the playbook. If it isn't,
+# specify any git URL as `control_repository_url`, leave `control_repository_name` blank, and
+# set up webhooks on the control repository manually.
+control_repository_name: deconst/control-example
+control_repository_url: https://github.com/{{ control_repository_name }}.git
 
 # Branch of the control repository that governs this deployment.
 control_repository_branch: master

--- a/provision.yml
+++ b/provision.yml
@@ -35,7 +35,7 @@
   - name: presenter load balancer
     rax_clb:
       name: deconst-presenter
-      port: 80
+      port: "{{ presenter_lb_port }}"
       wait: yes
       state: present
     register: clb_presenter
@@ -43,7 +43,7 @@
   - name: content service load balancer
     rax_clb:
       name: deconst-content-service
-      port: 9000
+      port: "{{ content_service_lb_port }}"
       wait: yes
       state: present
     register: clb_content_service
@@ -51,7 +51,7 @@
   - name: webhook service load balancer
     rax_clb:
       name: deconst-webhook-service
-      port: 9004
+      port: "{{ webhook_service_lb_port }}"
       wait: yes
       state: present
     register: clb_webhook_service

--- a/roles/worker/tasks/main.yml
+++ b/roles/worker/tasks/main.yml
@@ -66,7 +66,7 @@
     pull: always
     state: reloaded
     env:
-      ETCD_URL: "{{ etcd_host }}"
+      ETCD_URL: "http://{{ etcd_host }}"
       ETCD_PORT: "{{ etcd_api_port }}"
       CONTROL_REPO_TOKEN: "{{ control_repository_token }}"
       WEBHOOK_LOG_LEVEL: "{{ webhook_log_level }}"

--- a/site.yml
+++ b/site.yml
@@ -6,3 +6,5 @@
 - include: common.yml tags=common
 
 - include: worker.yml tags=worker
+
+- include: webhook.yml tags=webhook

--- a/vars.yml
+++ b/vars.yml
@@ -11,4 +11,4 @@ etcd_peer_port: 7001
 
 presenter_lb_port: 80
 content_service_lb_port: 9000
-webhook_service_lb_port: 9004
+webhook_service_lb_port: 9003

--- a/vars.yml
+++ b/vars.yml
@@ -8,3 +8,7 @@ image_id_coreos_alpha: 506c2025-e2db-4dc5-a7e3-2466a5dc3eed
 
 etcd_api_port: 4001
 etcd_peer_port: 7001
+
+presenter_lb_port: 80
+content_service_lb_port: 9000
+webhook_service_lb_port: 9004

--- a/webhook.yml
+++ b/webhook.yml
@@ -1,0 +1,20 @@
+---
+# Configure a webhook on the control repository.
+
+- name: webhooks
+  hosts: local
+  connection: local
+  gather_facts: no
+  vars_files:
+  - vars.yml
+  - credentials.yml
+  tasks:
+
+  - name: control repository webhook
+    github_hooks:
+      action: create
+      user: "{{ github_oauth_user }}"
+      oauthkey: "{{ github_oauth_token }}"
+      repo: https://api.github.com/repos/{{ control_repository_name }}
+      hookurl: http://{{ clb_webhook_service.balancer.virtual_ips[0].address }}:{{ clb_webhook_service.balancer.port }}
+    when: control_repository_name


### PR DESCRIPTION
The `github_hooks` module doesn't support secrets yet, so you still need to manually set that in your control repository's webhook settings. This will automatically create the webhook, though.
