### PR TITLE
Update load balancers in serial plays

### DIFF
--- a/roles/loadbalanced/tasks/main.yml
+++ b/roles/loadbalanced/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Add service nodes to the correct load balancers.
+# This must be run within a play with "serial: 1" to avoid update conflicts.
+
+- name: content service CLB nodes
+  local_action:
+    module: rax_clb_nodes
+    load_balancer_id: "{{ hostvars.localhost.clb_content_service.balancer.id }}"
+    address: "{{ ansible_eth1.ipv4.address }}"
+    port: "{{ 8990 + 10 * item|int }}"
+    wait: yes
+  with_sequence: count={{ pod_count }}
+
+- name: webhook service CLB nodes
+  local_action:
+    module: rax_clb_nodes
+    load_balancer_id: "{{ hostvars.localhost.clb_webhook_service.balancer.id }}"
+    address: "{{ ansible_eth1.ipv4.address }}"
+    port: "{{ 8993 + 10 * item|int }}"
+    wait: yes
+  with_sequence: count={{ pod_count }}
+
+- name: presenter CLB nodes
+  local_action:
+    module: rax_clb_nodes
+    load_balancer_id: "{{ hostvars.localhost.clb_presenter.balancer.id }}"
+    address: "{{ ansible_eth1.ipv4.address }}"
+    port: "{{ 79 + item|int }}"
+    wait: yes
+  with_sequence: count={{ pod_count }}

--- a/roles/worker/tasks/main.yml
+++ b/roles/worker/tasks/main.yml
@@ -20,15 +20,6 @@
     restart_policy: "{{ restart }}"
   with_sequence: count={{ pod_count }}
 
-- name: content service CLB nodes
-  local_action:
-    module: rax_clb_nodes
-    load_balancer_id: "{{ hostvars.localhost.clb_content_service.balancer.id }}"
-    address: "{{ ansible_eth1.ipv4.address }}"
-    port: "{{ 8990 + 10 * item|int }}"
-    wait: yes
-  with_sequence: count={{ pod_count }}
-
 - name: mapping service
   docker:
     name: mapping-service-{{ item }}
@@ -74,15 +65,6 @@
   with_sequence: count={{ pod_count }}
   register: webhook_services
 
-- name: webhook service CLB nodes
-  local_action:
-    module: rax_clb_nodes
-    load_balancer_id: "{{ hostvars.localhost.clb_webhook_service.balancer.id }}"
-    address: "{{ ansible_eth1.ipv4.address }}"
-    port: "{{ 8993 + 10 * item|int }}"
-    wait: yes
-  with_sequence: count={{ pod_count }}
-
 - name: etcd watcher service
   docker:
     name: etcd-watcher-{{ item }}
@@ -120,12 +102,3 @@
     restart_policy: "{{ restart }}"
   with_sequence: count={{ pod_count }}
   register: presenters
-
-- name: presenter CLB nodes
-  local_action:
-    module: rax_clb_nodes
-    load_balancer_id: "{{ hostvars.localhost.clb_presenter.balancer.id }}"
-    address: "{{ ansible_eth1.ipv4.address }}"
-    port: "{{ 79 + item|int }}"
-    wait: yes
-  with_sequence: count={{ pod_count }}

--- a/worker.yml
+++ b/worker.yml
@@ -7,3 +7,11 @@
   - credentials.yml
   roles:
   - worker
+
+- hosts: deconst-worker
+  serial: 1
+  vars_files:
+  - vars.yml
+  - credentials.yml
+  roles:
+  - loadbalanced


### PR DESCRIPTION
The `rax_clb_nodes` tasks in the worker role are trampling over each other, because Ansible is attempting to update the CLB on behalf of every host at once. `serial: 1` will ensure that those tasks will execute sequentially, instead.
