### PR TITLE
Relaunch etcd2 on reboot.

### DIFF
--- a/roles/common/tasks/etcd.yml
+++ b/roles/common/tasks/etcd.yml
@@ -3,12 +3,14 @@
 - name: derive the etcd client connection URL
   set_fact: etcd_api_url=http://{{ ansible_eth1.ipv4.address }}:{{ etcd_api_port }}
 
-- name: etcd2 unit file directory
-  file: state=directory path=/etc/systemd/system/etcd2.service.d owner=root group=root mode=0755
+- name: etcd2 unit file
+  template: src=etcd2.service.j2 dest=/etc/systemd/system/etcd2.service
+  register: etcd2_unit
   sudo: yes
 
-- name: etcd2 unit file
-  template: src=etcd-20-cluster.conf.j2 dest=/etc/systemd/system/etcd2.service.d/20-cluster.conf
+- name: reload systemctl daemon
+  command: systemctl daemon-reload
+  when: etcd2_unit | changed
   sudo: yes
 
 - name: etcd2 service

--- a/roles/common/tasks/etcd.yml
+++ b/roles/common/tasks/etcd.yml
@@ -3,6 +3,10 @@
 - name: derive the etcd client connection URL
   set_fact: etcd_api_url=http://{{ ansible_eth1.ipv4.address }}:{{ etcd_api_port }}
 
+- name: etcd2 unit file directory
+  file: state=directory path=/etc/systemd/system/etcd2.service.d owner=root group=root mode=0755
+  sudo: yes
+
 - name: etcd2 unit file
   template: src=etcd-20-cluster.conf.j2 dest=/etc/systemd/system/etcd2.service.d/20-cluster.conf
   sudo: yes

--- a/roles/common/tasks/etcd.yml
+++ b/roles/common/tasks/etcd.yml
@@ -4,11 +4,11 @@
   set_fact: etcd_api_url=http://{{ ansible_eth1.ipv4.address }}:{{ etcd_api_port }}
 
 - name: etcd2 unit file
-  template: src=etcd-20-cluster.conf.j2 dest=/run/systemd/system/etcd2.service.d/20-cluster.conf
+  template: src=etcd-20-cluster.conf.j2 dest=/etc/systemd/system/etcd2.service.d/20-cluster.conf
   sudo: yes
 
 - name: etcd2 service
-  service: name=etcd2.service state=started
+  service: name=etcd2.service enabled=yes state=started
   sudo: yes
 
 - name: ensure etcd2 is listening

--- a/roles/common/templates/etcd-20-cluster.conf.j2
+++ b/roles/common/templates/etcd-20-cluster.conf.j2
@@ -1,13 +1,15 @@
+# {{ ansible_managed }}
+
 [Service]
-Environment="ETCD_INITIAL_CLUSTER={% for host in groups['deconst-worker'] -%}
+Environment=ETCD_INITIAL_CLUSTER={% for host in groups['deconst-worker'] -%}
   {{ host }}=http://{{ hostvars[host].ansible_eth1.ipv4.address }}:{{ etcd_peer_port }}
   {%- if not loop.last %},{% endif -%}
-{%- endfor %}"
-Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{ ansible_eth1.ipv4.address }}:{{ etcd_peer_port }}"
-Environment="ETCD_INITIAL_CLUSTER_STATE={% if hostvars.localhost.fresh_cluster %}new{% else %}existing{% endif %}"
-Environment="ETCD_INITIAL_CLUSTER_TOKEN={{ hostvars.localhost.etcd_cluster_token }}"
+{%- endfor %}
+Environment=ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{ ansible_eth1.ipv4.address }}:{{ etcd_peer_port }}
+Environment=ETCD_INITIAL_CLUSTER_STATE={% if hostvars.localhost.fresh_cluster %}new{% else %}existing{% endif %}
+Environment=ETCD_INITIAL_CLUSTER_TOKEN={{ hostvars.localhost.etcd_cluster_token }}
 
-Environment="ETCD_NAME={{ inventory_hostname }}"
-Environment="ETCD_LISTEN_PEER_URLS=http://127.0.0.1:{{ etcd_peer_port }},http://{{ ansible_eth1.ipv4.address }}:{{ etcd_peer_port }}"
-Environment="ETCD_LISTEN_CLIENT_URLS=http://127.0.0.1:{{ etcd_api_port }},{{ etcd_api_url }}"
-Environment="ETCD_ADVERTISE_CLIENT_URLS={{ etcd_api_url }}"
+Environment=ETCD_NAME={{ inventory_hostname }}
+Environment=ETCD_LISTEN_PEER_URLS=http://127.0.0.1:{{ etcd_peer_port }},http://{{ ansible_eth1.ipv4.address }}:{{ etcd_peer_port }}
+Environment=ETCD_LISTEN_CLIENT_URLS=http://127.0.0.1:{{ etcd_api_port }},{{ etcd_api_url }}
+Environment=ETCD_ADVERTISE_CLIENT_URLS={{ etcd_api_url }}

--- a/roles/common/templates/etcd-20-cluster.conf.j2
+++ b/roles/common/templates/etcd-20-cluster.conf.j2
@@ -5,8 +5,10 @@ Environment=ETCD_INITIAL_CLUSTER={% for host in groups['deconst-worker'] -%}
   {{ host }}=http://{{ hostvars[host].ansible_eth1.ipv4.address }}:{{ etcd_peer_port }}
   {%- if not loop.last %},{% endif -%}
 {%- endfor %}
+
 Environment=ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{ ansible_eth1.ipv4.address }}:{{ etcd_peer_port }}
 Environment=ETCD_INITIAL_CLUSTER_STATE={% if hostvars.localhost.fresh_cluster %}new{% else %}existing{% endif %}
+
 Environment=ETCD_INITIAL_CLUSTER_TOKEN={{ hostvars.localhost.etcd_cluster_token }}
 
 Environment=ETCD_NAME={{ inventory_hostname }}

--- a/roles/common/templates/etcd2.service.j2
+++ b/roles/common/templates/etcd2.service.j2
@@ -1,6 +1,18 @@
 # {{ ansible_managed }}
 
+[Unit]
+Description=etcd2
+Conflicts=etcd.service
+
 [Service]
+User=etcd
+Environment=ETCD_DATA_DIR=/var/lib/etcd2
+ExecStart=/usr/bin/etcd2
+Restart=always
+RestartSec=10s
+LimitNOFILE=40000
+
+# Static cluster bootstrapping configuration
 Environment=ETCD_INITIAL_CLUSTER={% for host in groups['deconst-worker'] -%}
   {{ host }}=http://{{ hostvars[host].ansible_eth1.ipv4.address }}:{{ etcd_peer_port }}
   {%- if not loop.last %},{% endif -%}
@@ -11,7 +23,13 @@ Environment=ETCD_INITIAL_CLUSTER_STATE={% if hostvars.localhost.fresh_cluster %}
 
 Environment=ETCD_INITIAL_CLUSTER_TOKEN={{ hostvars.localhost.etcd_cluster_token }}
 
+# General service configuration
+
 Environment=ETCD_NAME={{ inventory_hostname }}
 Environment=ETCD_LISTEN_PEER_URLS=http://127.0.0.1:{{ etcd_peer_port }},http://{{ ansible_eth1.ipv4.address }}:{{ etcd_peer_port }}
 Environment=ETCD_LISTEN_CLIENT_URLS=http://127.0.0.1:{{ etcd_api_port }},{{ etcd_api_url }}
 Environment=ETCD_ADVERTISE_CLIENT_URLS={{ etcd_api_url }}
+Environment=ETCD_ELECTION_TIMEOUT=1200
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
It turns out that `/run/systemd` is wiped on boot. :notes:

deconst/deconst-docs#79
