### PR TITLE
Make the ssh IP whitelist optional

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -94,4 +94,5 @@ github_oauth_token:
 content_admin_apikey:
 
 # List of IP addresses from which incoming SSH connections should be accepted.
-source_addresses:
+# Leave this as an empty collection to accept SSH connections from any IP.
+source_addresses: []

--- a/roles/common/files/sshd_config
+++ b/roles/common/files/sshd_config
@@ -1,0 +1,11 @@
+# Use most defaults for sshd configuration.
+UsePrivilegeSeparation sandbox
+Subsystem sftp internal-sftp
+ClientAliveInterval 180
+UseDNS no
+
+# Customizations
+PermitRootLogin no
+AllowUsers core
+PasswordAuthentication no
+ChallengeResponseAuthentication no

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
 
+- name: docker-py
+  pip: name=docker-py state=present version=1.1.0
+
+- name: disable password authentication over SSH
+  copy: src=sshd_config dest=/etc/ssh/sshd_config owner=root group=root mode=0644
+  sudo: yes
+
 - include: accounts.yml
 
 - include: etcd.yml
-
-- name: docker-py
-  pip: name=docker-py state=present version=1.1.0

--- a/roles/firewalled/templates/rules-save.j2
+++ b/roles/firewalled/templates/rules-save.j2
@@ -13,6 +13,8 @@
 # Allow SSH access from specific hosts
 {% for addr in source_addresses %}
 -A INPUT -i eth0 -p tcp -m tcp --source {{ addr }} --dport 22 -j ACCEPT
+{% else %}
+-A INPUT -i eth0 -p tcp -m tcp --dport 22 -j ACCEPT
 {% endfor %}
 
 # etcd peering and clients over ServiceNet


### PR DESCRIPTION
This will make deploying to our staging server a lot less painful.

Reference: deconst/deconst-docs#97
