### PR TITLE
Use image names instead of UUIDs.

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -17,7 +17,7 @@
       group: deconst-worker-{{ instance }}-{{ deployment }}
       count: "{{ worker_count }}"
       exact_count: yes
-      image: "{{ image_id_coreos_beta }}"
+      image: "{{ image_coreos_beta }}"
       flavor: "{{ worker_flavor }}"
       key_name: "{{ rackspace_keyname }}"
       wait: yes

--- a/vars.yml
+++ b/vars.yml
@@ -1,10 +1,10 @@
 ---
 # Common variables
 
-image_id_ubuntu_1404: 6909f56c-bd77-411a-8c0e-c37876b68d1d
-image_id_coreos_stable: a202bb99-23d3-4c42-a26f-778c2f974e6a
-image_id_coreos_beta: 21289dcb-d757-4a45-9058-28151386d155
-image_id_coreos_alpha: f8f8c267-b3a8-49a9-839f-09977b458762
+image_ubuntu_1504: Ubuntu 15.04 (Vivid Vervet) (PVHVM)
+image_coreos_stable: CoreOS (Stable)
+image_coreos_beta: CoreOS (Beta)
+image_coreos_alpha: CoreOS (Alpha)
 
 etcd_api_port: 2379
 etcd_peer_port: 2380


### PR DESCRIPTION
Fixes deconst/deconst-docs#68 at long last. Also keeps my CoreOS hosts from launching with docker 1.5.0 and rebooting immediately. :sparkles:
