### PR TITLE
Restart more slowly for loadbalanced containers.

### DIFF
--- a/roles/worker/files/services/content@.service
+++ b/roles/worker/files/services/content@.service
@@ -31,6 +31,7 @@ ExecStop=/usr/bin/docker stop --time=2 content-service-%i
 ExecStop=/usr/bin/docker rm -f content-service-%i
 
 Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/worker/files/services/presenter@.service
+++ b/roles/worker/files/services/presenter@.service
@@ -30,6 +30,7 @@ ExecStop=/usr/bin/docker stop --time=2 presenter-%i
 ExecStop=/usr/bin/docker rm -f presenter-%i
 
 Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/worker/files/services/webhook@.service
+++ b/roles/worker/files/services/webhook@.service
@@ -24,6 +24,7 @@ ExecStop=/usr/bin/docker stop --time=2 webhook-service-%i
 ExecStop=/usr/bin/docker rm -f webhook-service-%i
 
 Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This should make the services less likely to overwhelm CLB rate limits.
