### PR TITLE
Use a static binary for peekaboo.

### DIFF
--- a/roles/worker/files/scripts/peekaboo-down
+++ b/roles/worker/files/scripts/peekaboo-down
@@ -35,27 +35,16 @@ APP_PORT=$(/usr/bin/docker inspect \
 
 echo "Draining ${CONTAINER_NAME}:${APP_PORT} from the load balancer ${LOAD_BALANCER_ID}."
 
-/usr/bin/docker run \
-  --rm=true \
-  --net=host \
-  --env=LOAD_BALANCER_ID=${LOAD_BALANCER_ID} \
-  --env=OS_USERNAME=${RACKSPACE_USERNAME} \
-  --env=OS_PASSWORD=${RACKSPACE_APIKEY} \
-  --env=OS_REGION_NAME=${RACKSPACE_REGION} \
-  --env=APP_PORT=${APP_PORT} \
-  rgbkrk/peekaboo -drain
+export LOAD_BALANCER_ID=${LOAD_BALANCER_ID}
+export OS_USERNAME=${RACKSPACE_USERNAME}
+export OS_PASSWORD=${RACKSPACE_APIKEY}
+export OS_REGION_NAME=${RACKSPACE_REGION}
+export APP_PORT=${APP_PORT}
+
+/opt/bin/peekaboo -drain
 
 # Give connections a chance to drain.
 sleep 3
 
 echo "Deleting ${CONTAINER_NAME}:${APP_PORT} on the load balancer ${LOAD_BALANCER_ID}."
-
-/usr/bin/docker run \
-  --rm=true \
-  --net=host \
-  --env=LOAD_BALANCER_ID=${LOAD_BALANCER_ID} \
-  --env=OS_USERNAME=${RACKSPACE_USERNAME} \
-  --env=OS_PASSWORD=${RACKSPACE_APIKEY} \
-  --env=OS_REGION_NAME=${RACKSPACE_REGION} \
-  --env=APP_PORT=${APP_PORT} \
-  rgbkrk/peekaboo -delete
+/opt/bin/peekaboo -delete

--- a/roles/worker/files/scripts/peekaboo-up
+++ b/roles/worker/files/scripts/peekaboo-up
@@ -43,12 +43,10 @@ APP_PORT=$(/usr/bin/docker inspect \
 
 echo "Adding ${CONTAINER_NAME}:${APP_PORT} to the load balancer ${LOAD_BALANCER_ID}."
 
-/usr/bin/docker run \
-  --rm=true \
-  --net=host \
-  --env=LOAD_BALANCER_ID=${LOAD_BALANCER_ID} \
-  --env=OS_USERNAME=${RACKSPACE_USERNAME} \
-  --env=OS_PASSWORD=${RACKSPACE_APIKEY} \
-  --env=OS_REGION_NAME=${RACKSPACE_REGION} \
-  --env=APP_PORT=${APP_PORT} \
-  rgbkrk/peekaboo
+export LOAD_BALANCER_ID=${LOAD_BALANCER_ID}
+export OS_USERNAME=${RACKSPACE_USERNAME}
+export OS_PASSWORD=${RACKSPACE_APIKEY}
+export OS_REGION_NAME=${RACKSPACE_REGION}
+export APP_PORT=${APP_PORT}
+
+/opt/bin/peekaboo

--- a/roles/worker/files/services/deconst-content@.service
+++ b/roles/worker/files/services/deconst-content@.service
@@ -5,7 +5,7 @@ After=docker.service
 
 [Service]
 EnvironmentFile=/etc/deconst/environment.sh
-TimeoutSec=0
+TimeoutSec=5min
 Type=notify
 NotifyAccess=all
 

--- a/roles/worker/files/services/deconst-presenter@.service
+++ b/roles/worker/files/services/deconst-presenter@.service
@@ -5,7 +5,7 @@ After=   docker.service deconst-content@%i.service
 
 [Service]
 EnvironmentFile=/etc/deconst/environment.sh
-TimeoutSec=0
+TimeoutSec=5min
 Type=notify
 NotifyAccess=all
 

--- a/roles/worker/tasks/main.yml
+++ b/roles/worker/tasks/main.yml
@@ -52,8 +52,15 @@
   get_url: dest=/opt/bin/systemd-docker url=https://github.com/ibuildthecloud/systemd-docker/releases/download/v0.2.0/systemd-docker
   sudo: yes
 
-- name: systemd-docker is executable
-  file: path=/opt/bin/systemd-docker mode=0755
+- name: peekaboo binary
+  get_url: dest=/opt/bin/peekaboo url=https://github.com/rgbkrk/peekaboo/releases/download/v0.0.1-alpha/peekaboo
+  sudo: yes
+
+- name: systemd-docker and peekaboo are executable
+  file: path=/opt/bin/{{ item }} mode=0755
+  with_items:
+  - systemd-docker
+  - peekaboo
   sudo: yes
 
 - name: ensure containers are up to date


### PR DESCRIPTION
There are problems running docker containers in `ExecStop` actions of CoreOS systemd service units; the process seems to lose its docker connection shortly after launch, which is leaving our peekaboo containers in weird states (or not working at all).

This should address deconst/deconst-docs#113.
