### PR TITLE
Tag the service restart action.

### DIFF
--- a/restart.yml
+++ b/restart.yml
@@ -18,3 +18,4 @@
     - services
     when: (environment|changed or service_pulls|changed or units|changed) and not (containers|changed)
     sudo: yes
+    tags: restart


### PR DESCRIPTION
This will let us opt out of the rolling service restarts if, for example, we want to do them manually to verify the results.
