### PR TITLE
Get script/logs working again

### DIFF
--- a/script/logs
+++ b/script/logs
@@ -30,7 +30,7 @@ lines = int(os.environ.get("LOG_LINES", "100"))
 
 for server in cs.servers.list():
     group = server.metadata.get('group')
-    if group not in ("deconst-worker",):
+    if not group.startswith("deconst-worker"):
         continue
 
     print "*{:*^78}*".format(" SERVER: " + server.name + " ")


### PR DESCRIPTION
I'd changed the server group names and forgotten to update `script/logs` to match. It's working again, now.
