### PR TITLE
Don't run containers with --rm

### DIFF
--- a/roles/worker/files/services/deconst-content@.service
+++ b/roles/worker/files/services/deconst-content@.service
@@ -10,7 +10,6 @@ Type=notify
 NotifyAccess=all
 
 ExecStart=/opt/bin/systemd-docker run \
-  --rm \
   --name=content-service-%i \
   --env=RACKSPACE_USERNAME=${RACKSPACE_USERNAME} \
   --env=RACKSPACE_APIKEY=${RACKSPACE_APIKEY} \

--- a/roles/worker/files/services/deconst-content@.service
+++ b/roles/worker/files/services/deconst-content@.service
@@ -9,6 +9,8 @@ TimeoutSec=5min
 Type=notify
 NotifyAccess=all
 
+ExecStartPre=-/usr/bin/docker rm -f content-service-%i
+
 ExecStart=/opt/bin/systemd-docker run \
   --name=content-service-%i \
   --env=RACKSPACE_USERNAME=${RACKSPACE_USERNAME} \

--- a/roles/worker/files/services/deconst-presenter@.service
+++ b/roles/worker/files/services/deconst-presenter@.service
@@ -9,6 +9,8 @@ TimeoutSec=5min
 Type=notify
 NotifyAccess=all
 
+ExecStartPre=-/usr/bin/docker rm -f presenter-%i
+
 ExecStart=/opt/bin/systemd-docker run \
   --name=presenter-%i \
   --link=content-service-%i:content-service \

--- a/roles/worker/files/services/deconst-presenter@.service
+++ b/roles/worker/files/services/deconst-presenter@.service
@@ -10,7 +10,6 @@ Type=notify
 NotifyAccess=all
 
 ExecStart=/opt/bin/systemd-docker run \
-  --rm \
   --name=presenter-%i \
   --link=content-service-%i:content-service \
   --env=CONTENT_SERVICE_URL=http://content-service:8080/ \


### PR DESCRIPTION
This should give peekaboo a chance to inspect the public port of a dead container and clean it up properly.
