### PR TITLE
Reinstate --rm

### DIFF
--- a/roles/worker/files/services/deconst-content@.service
+++ b/roles/worker/files/services/deconst-content@.service
@@ -9,9 +9,8 @@ TimeoutSec=5min
 Type=notify
 NotifyAccess=all
 
-ExecStartPre=-/usr/bin/docker rm -f content-service-%i
-
 ExecStart=/opt/bin/systemd-docker run \
+  --rm \
   --name=content-service-%i \
   --env=RACKSPACE_USERNAME=${RACKSPACE_USERNAME} \
   --env=RACKSPACE_APIKEY=${RACKSPACE_APIKEY} \

--- a/roles/worker/files/services/deconst-presenter@.service
+++ b/roles/worker/files/services/deconst-presenter@.service
@@ -9,9 +9,8 @@ TimeoutSec=5min
 Type=notify
 NotifyAccess=all
 
-ExecStartPre=-/usr/bin/docker rm -f presenter-%i
-
 ExecStart=/opt/bin/systemd-docker run \
+  --rm \
   --name=presenter-%i \
   --link=content-service-%i:content-service \
   --env=CONTENT_SERVICE_URL=http://content-service:8080/ \


### PR DESCRIPTION
Running without `--rm` didn't actually work anyway; peekaboo-down still couldn't find the public port of the dead node. Back to the drawing board for that one.
