### PR TITLE
Record container ports in a text file.

### DIFF
--- a/roles/worker/files/scripts/peekaboo-down
+++ b/roles/worker/files/scripts/peekaboo-down
@@ -17,16 +17,16 @@ USAGE
 CONTAINER_NAME=${1:-}
 LOAD_BALANCER_ID=${2:-}
 
-# Exit quietly if the container does not exist.
-/usr/bin/docker inspect ${CONTAINER_NAME} >/dev/null 2>&1 || {
-  echo "Container ${CONTAINER_NAME} does not exist."
-  exit 0
+# Locate the published port to add to the load balancer.
+
+PORT_PATH=/var/deconst/ports/${CONTAINER_NAME}.port
+
+[ -e ${PORT_PATH} ] || {
+  echo "Port file ${PORT_PATH} does not exist."
+  exit 1
 }
 
-# Locate the published port to add to the load balancer.
-APP_PORT=$(/usr/bin/docker inspect \
-  --format='{{index .NetworkSettings.Ports "8080/tcp" 0 "HostPort" }}' \
-  ${CONTAINER_NAME})
+APP_PORT=$(cat ${PORT_PATH})
 
 [ -z ${APP_PORT} ] && {
   echo "Unable to find the application port for container ${CONTAINER_NAME}" >&2
@@ -46,5 +46,8 @@ export APP_PORT=${APP_PORT}
 # Give connections a chance to drain.
 sleep 3
 
-echo "Deleting ${CONTAINER_NAME}:${APP_PORT} on the load balancer ${LOAD_BALANCER_ID}."
+echo "Deleting ${CONTAINER_NAME}:${APP_PORT} from the load balancer ${LOAD_BALANCER_ID}."
 /opt/bin/peekaboo -delete
+
+echo "Removing port file ${PORT_PATH}."
+rm -f "${PORT_PATH}"

--- a/roles/worker/files/scripts/peekaboo-up
+++ b/roles/worker/files/scripts/peekaboo-up
@@ -17,24 +17,16 @@ USAGE
 CONTAINER_NAME=${1:-}
 LOAD_BALANCER_ID=${2:-}
 
-# Wait for the container to exist.
-ATTEMPT=0
-while ! /usr/bin/docker inspect ${CONTAINER_NAME} >/dev/null 2>&1 ; do
-  [ ${ATTEMPT} -lt 300 ] || {
-    echo "${CONTAINER_NAME} never launched." >&2
-    exit 1
-  }
-
-  echo "Waiting for ${CONTAINER_NAME} to launch: ${ATTEMPT}"
-  ATTEMPT=$(( ${ATTEMPT} + 1 ))
-
-  sleep 1
-done
-
 # Locate the published port to add to the load balancer.
-APP_PORT=$(/usr/bin/docker inspect \
-  --format='{{index .NetworkSettings.Ports "8080/tcp" 0 "HostPort" }}' \
-  ${CONTAINER_NAME})
+
+PORT_PATH=/var/deconst/ports/${CONTAINER_NAME}.port
+
+[ -e ${PORT_PATH} ] || {
+  echo "Port file ${PORT_PATH} does not exist."
+  exit 1
+}
+
+APP_PORT=$(cat ${PORT_PATH})
 
 [ -z ${APP_PORT} ] && {
   echo "Unable to find the application port for container ${CONTAINER_NAME}" >&2

--- a/roles/worker/files/scripts/record-port
+++ b/roles/worker/files/scripts/record-port
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Record the port number of the container named as the first argument.
+
+set -eou pipefail
+
+CONTAINER_NAME=${1:-}
+
+[ -z "${CONTAINER_NAME}" ] && {
+  cat <<USAGE >&2
+Usage: record-port <container>
+
+  Creates a file containing the publicly exposed port of a named container to a file at:
+  /var/deconst/ports/<container-name>.port
+USAGE
+  exit 1
+}
+
+PORT_PATH=/var/deconst/ports/${CONTAINER_NAME}.port
+
+# Remove any pre-existing file at that path.
+[ -e "${PORT_PATH}" ] && {
+  echo "Removing pre-existing file ${PORT_PATH}."
+  rm -f "${PORT_PATH}"
+}
+
+# Wait for the container to exist.
+ATTEMPT=0
+while ! /usr/bin/docker inspect ${CONTAINER_NAME} >/dev/null 2>&1 ; do
+  [ ${ATTEMPT} -lt 300 ] || {
+    echo "${CONTAINER_NAME} never launched." >&2
+    exit 1
+  }
+
+  echo "Waiting for ${CONTAINER_NAME} to launch: ${ATTEMPT}"
+  ATTEMPT=$(( ${ATTEMPT} + 1 ))
+
+  sleep 1
+done
+
+# Locate the published port to add to the load balancer.
+APP_PORT=$(/usr/bin/docker inspect \
+  --format='{{index .NetworkSettings.Ports "8080/tcp" 0 "HostPort" }}' \
+  ${CONTAINER_NAME})
+
+# Write the port number to the appropriate path.
+echo "Writing port ${APP_PORT} to ${PORT_PATH} for container ${CONTAINER_NAME}."
+echo -n ${APP_PORT} > ${PORT_PATH}

--- a/roles/worker/files/services/deconst-content@.service
+++ b/roles/worker/files/services/deconst-content@.service
@@ -24,6 +24,7 @@ ExecStart=/opt/bin/systemd-docker run \
   --publish=0.0.0.0::8080 \
   quay.io/deconst/content-service
 
+ExecStartPost=/opt/bin/record-port content-service-%i
 ExecStartPost=/opt/bin/peekaboo-up content-service-%i ${CONTENT_LB_ID}
 
 ExecStop=/opt/bin/peekaboo-down content-service-%i ${CONTENT_LB_ID}

--- a/roles/worker/files/services/deconst-presenter@.service
+++ b/roles/worker/files/services/deconst-presenter@.service
@@ -21,6 +21,7 @@ ExecStart=/opt/bin/systemd-docker run \
   --publish=0.0.0.0::8080 \
   quay.io/deconst/presenter
 
+ExecStartPost=/opt/bin/record-port presenter-%i
 ExecStartPost=/opt/bin/peekaboo-up presenter-%i ${PRESENTER_LB_ID}
 
 ExecStop=/opt/bin/peekaboo-down presenter-%i ${PRESENTER_LB_ID}

--- a/roles/worker/tasks/main.yml
+++ b/roles/worker/tasks/main.yml
@@ -13,7 +13,7 @@
     mode: 0755
   with_items:
   - /etc/deconst
-  - /var/deconst
+  - /var/deconst/ports
   - /opt/bin
   sudo: yes
 
@@ -35,6 +35,7 @@
     group: root
     mode: 0755
   with_items:
+  - record-port
   - peekaboo-up
   - peekaboo-down
   sudo: yes


### PR DESCRIPTION
If a container dies abnormally, the `peekaboo-down` script has no way to know which ports to drain and delete from the load balancer. Instead, store the container's public port into a text file on service launch, and use that in place of `docker inspect`.
