### PR TITLE
Enable and disable diagnostics

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -58,6 +58,9 @@ map_log_level: "{{ log_level }}"
 presenter_log_level: "{{ log_level }}"
 webhook_log_level: "{{ log_level }}"
 
+# Enable or disable diagnostics that are dangerous to enable in production.
+# enable_diagnostics: yes
+
 # Restart policy for the service containers.
 #
 # Set this to "no" (with the quotes) to disable automatic container restarts on the cluster. This

--- a/roles/worker/files/services/deconst-presenter@.service
+++ b/roles/worker/files/services/deconst-presenter@.service
@@ -16,6 +16,7 @@ ExecStart=/opt/bin/systemd-docker run \
   --env=CONTENT_SERVICE_URL=http://content-service:8080/ \
   --env=CONTROL_REPO_PATH=/var/deconst/control \
   --env=PRESENTED_URL_DOMAIN=${PRESENTED_URL_DOMAIN} \
+  --env=PRESENTER_DIAGNOSTICS=${PRESENTER_DIAGNOSTICS} \
   --env=PRESENTER_LOG_LEVEL=${PRESENTER_LOG_LEVEL} \
   --volume=/var/deconst/control:/var/deconst/control:ro \
   --publish=0.0.0.0::8080 \

--- a/roles/worker/templates/deconst-environment.j2
+++ b/roles/worker/templates/deconst-environment.j2
@@ -33,6 +33,9 @@ ASSET_CONTAINER={{ asset_container }}
 # Presenter
 
 PRESENTED_URL_DOMAIN={{ presented_url_domain or '' }}
+{% if enable_diagnostics is defined and enable_diagnostics %}
+PRESENTER_DIAGNOSTICS="true"
+{% endif %}
 
 # Service Logging
 

--- a/script/logs
+++ b/script/logs
@@ -30,7 +30,7 @@ lines = int(os.environ.get("LOG_LINES", "100"))
 
 for server in cs.servers.list():
     group = server.metadata.get('group')
-    if not group.startswith("deconst-worker"):
+    if not group or not group.startswith("deconst-worker"):
         continue
 
     print "*{:*^78}*".format(" SERVER: " + server.name + " ")


### PR DESCRIPTION
Toggle the diagnostic flag introduced in deconst/presenter#51. Done without requiring any fiddling with existing `credentials.yml` files because they're annoying to update :wink:
