### PR TITLE
Get script/genkey working properly on production.

### DIFF
--- a/script/genkey
+++ b/script/genkey
@@ -20,36 +20,56 @@ root = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 # Collect credentials.
 with open(os.path.join(root, "credentials.yml")) as credfile:
     creds = yaml.load(credfile)
-rackspace_username = creds["rackspace_username"]
-rackspace_apikey = creds["rackspace_api_key"]
-rackspace_region = creds["rackspace_region"]
+
 admin_apikey = re.sub(r'\s+', "", creds["content_admin_apikey"])
 
-instance_name = creds["instance"]
+content_store_url = os.environ.get("CONTENT_STORE_URL")
+if content_store_url:
+    if content_store_url.endswith("/"):
+        content_store_url = content_store_url[:-1]
 
-pyrax.set_setting("identity_type", "rackspace")
-pyrax.set_setting("region", rackspace_region)
-pyrax.set_credentials(rackspace_username, rackspace_apikey)
-clb = pyrax.cloud_loadbalancers
+    print("Using content store URL: {}".format(content_store_url))
+else:
+    rackspace_username = creds["rackspace_username"]
+    rackspace_apikey = creds["rackspace_api_key"]
+    rackspace_region = creds["rackspace_region"]
 
-the_lb = None
-content_lb_name = "deconst-{}-content".format(instance_name)
-for lb in clb.list():
-    if lb.name == content_lb_name:
-        the_lb = lb
+    instance_name = creds["instance"]
 
-if not the_lb:
-    raise Exception("Content service load balancer not found")
+    pyrax.set_setting("identity_type", "rackspace")
+    pyrax.set_setting("region", rackspace_region)
+    pyrax.set_credentials(rackspace_username, rackspace_apikey)
+    clb = pyrax.cloud_loadbalancers
 
-addr = the_lb.virtual_ips[0].address
-port = the_lb.port
+    the_lb = None
+    content_lb_name = "deconst-{}-content".format(instance_name)
+    for lb in clb.list():
+        if lb.name == content_lb_name:
+            the_lb = lb
+
+    if not the_lb:
+        raise Exception("Content service load balancer not found")
+
+    addr = the_lb.virtual_ips[0].address
+    port = the_lb.port
+    proto = "http"
+
+    ssl_termination = the_lb.get_ssl_termination()
+    if ssl_termination:
+        proto = "https"
+        port = ssl_termination["securePort"]
+
+    content_store_url = "{}://{}:{}".format(proto, addr, port)
+
+    print("Derived content store URL: {}".format(content_store_url))
+    print("If this is incorrect, set CONTENT_STORE_URL to the correct value.")
 
 cmd = [
     "curl",
     "-s",
     "-X", "POST",
     "-H", 'Authorization: deconst apikey="{}"'.format(admin_apikey),
-    "http://{}:{}/keys?named={}".format(addr, port, keyname)
+    "{}/keys?named={}".format(content_store_url, keyname)
 ]
 
 stdout = subprocess.check_output(cmd)


### PR DESCRIPTION
Because the production CLB uses SSL termination and a certificate signed to "developer.rackspace.com", the automatic content store URL derivation wasn't working. This allows you to override it with:

``` bash
CONTENT_STORE_URL=https://developer.rackspace.com:9000/ script/genkey keynamehere
```

Not perfect, but it'll do.
