### PR TITLE
Increase the CLB timeout to 120s.

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -100,6 +100,7 @@
       port: "{{ content_service_lb_port }}"
       vip_id: "{{ clb_vip_id }}"
       wait: yes
+      timeout: 120
       state: present
     register: clb_content_service
 


### PR DESCRIPTION
Once in a while, the latency for storing assets in cloud files spikes up to around 60s. This bumps up the CLB's timeout so it doesn't kill the connection and return a premature 500 for those requests.
