### PR TITLE
Improve service restart coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ To only update the control repository's content map, layout map or templates:
 script/deploy --tags control
 ```
 
+To force a restart of selected services:
+
+```bash
+# Restart only presenters
+script/deploy --tags restart -e 'presenter_restart=true'
+
+# Other restart control variables:
+# -e 'service_pod_restart=true'         Service pods (content services and presenter)
+# -e 'logstash_forwarder_restart=true'  Logstash-forwarder
+# -e 'logstash_restart=true'            Logstash
+# -e 'kibana_restart=true'              Kibana
+```
+
 To force the generation of new TLS certificates:
 
 ```bash

--- a/restart.yml
+++ b/restart.yml
@@ -11,11 +11,16 @@
   serial: 1
   tasks:
 
+  # The service module is smart: when you use it with with_nested or with_items, it consolidates
+  # actions into a single invocation of the underlying binary (systemctl). However, this is exactly
+  # what we *don't* want here, because then all of the services do the charging herd thing on their
+  # load balancers.
+  #
+  # Instead, manually restart each pod together by invoking systemctl directly.
   - name: restart services
-    service: name={{ item[1] }}@{{ item[0] }}.service state=restarted
-    with_nested:
+    command: systemctl restart deconst-content@{{ item }}.service deconst-presenter@{{ item }}.service
+    with_items:
     - pod_names
-    - worker_services
     when: (environment|changed or worker_pulls|changed or worker_units|changed) and not (worker_service_results|changed)
     sudo: yes
     tags: restart

--- a/restart.yml
+++ b/restart.yml
@@ -17,17 +17,25 @@
   # load balancers.
   #
   # Instead, manually restart each pod together by invoking systemctl directly.
-  - name: restart services
+  - name: restart service pods
     command: systemctl restart deconst-content@{{ item }}.service deconst-presenter@{{ item }}.service
     with_items:
     - pod_names
-    when: (environment|changed or worker_pulls|changed or worker_units|changed) and not (worker_service_results|changed)
+    when: service_pod_restart|default(false)
+    sudo: yes
+    tags: restart
+
+  - name: restart presenters only
+    command: systemctl restart deconst-presenter@{{ item }}.service
+    with_items:
+    - pod_names
+    when: presenter_restart|default(false)
     sudo: yes
     tags: restart
 
   - name: restart logstash-forwarder
     service: name=logstash-forwarder state=restarted
-    when: (lf_binary|changed or lf_config|changed or lf_unit|changed) and not (lf_service_result|changed)
+    when: logstash_forwarder_restart|default(false)
     sudo: yes
     tags: restart
 
@@ -37,12 +45,12 @@
 
   - name: restart logstash
     service: name=deconst-logstash.service state=restarted
-    when: (elastic_pulls|changed or logstash_config|changed or units|changed) and not (elastic_service_results|changed)
+    when: logstash_restart|default(false)
     sudo: yes
     tags: restart
 
   - name: restart kibana
     service: name=deconst-kibana.service state=restarted
-    when: (elastic_pulls|changed or kibana_config|changed or units|changed) and not (elastic_service_results|changed)
+    when: kibana_restart|default(false)
     sudo: yes
     tags: restart

--- a/roles/elk/tasks/main.yml
+++ b/roles/elk/tasks/main.yml
@@ -64,3 +64,10 @@
   with_items: elastic_services
   register: elastic_service_results
   sudo: yes
+
+- name: compute restart control vars
+  set_fact:
+    logstash_restart: >
+      {{ (elastic_pulls|changed or logstash_config|changed or units|changed) and not (elastic_service_results|changed) }}
+    kibana_restart: >
+      {{ (elastic_pulls|changed or kibana_config|changed or units|changed) and not (elastic_service_results|changed) }}

--- a/roles/worker/tasks/main.yml
+++ b/roles/worker/tasks/main.yml
@@ -98,7 +98,7 @@
   when: worker_units|changed or lf_unit|changed
   sudo: yes
 
-- name: container services
+- name: container service pods
   service: name={{ item[1] }}@{{ item[0] }}.service state=started enabled=true
   with_nested:
   - pod_names
@@ -110,3 +110,10 @@
   service: name=logstash-forwarder.service state=started enabled=true
   register: lf_service_result
   sudo: yes
+
+- name: compute restart control vars
+  set_fact:
+    service_pod_restart: >
+      {{ (environment|changed or worker_pulls|changed or worker_units|changed) and not (worker_service_results|changed) }}
+    logstash_forwarder_restart: >
+      {{ (lf_binary|changed or lf_config|changed or lf_unit|changed) and not (lf_service_result|changed) }}


### PR DESCRIPTION
The `restart.yml` tasks have been failing often enough to make them nigh unusable. This improves the flow so that:
- Each pod is restarted individually and serially. Ansible's service module collapses `with_nested` invocations together to a single `systemctl` invocation, which was triggering the same thundering herd problem that I was trying to avoid in the first place.
- Each restart task is guarded by a variable, populated within the system's role, that can be overridden by a `-e` option at runtime. This makes `script/deploy --tags restart` useful.
- Add a task to restart only the presenters in each pod.
