### PR TITLE
Cast to bool to avoid unnecessary restarts.

### DIFF
--- a/restart.yml
+++ b/restart.yml
@@ -21,7 +21,7 @@
     command: systemctl restart deconst-content@{{ item }}.service deconst-presenter@{{ item }}.service
     with_items:
     - pod_names
-    when: service_pod_restart|default(false)
+    when: service_pod_restart|default(false)|bool
     sudo: yes
     tags: restart
 
@@ -29,13 +29,13 @@
     command: systemctl restart deconst-presenter@{{ item }}.service
     with_items:
     - pod_names
-    when: presenter_restart|default(false)
+    when: presenter_restart|default(false)|bool
     sudo: yes
     tags: restart
 
   - name: restart logstash-forwarder
     service: name=logstash-forwarder state=restarted
-    when: logstash_forwarder_restart|default(false)
+    when: logstash_forwarder_restart|default(false)|bool
     sudo: yes
     tags: restart
 
@@ -45,12 +45,12 @@
 
   - name: restart logstash
     service: name=deconst-logstash.service state=restarted
-    when: logstash_restart|default(false)
+    when: logstash_restart|default(false)|bool
     sudo: yes
     tags: restart
 
   - name: restart kibana
     service: name=deconst-kibana.service state=restarted
-    when: kibana_restart|default(false)
+    when: kibana_restart|default(false)|bool
     sudo: yes
     tags: restart

--- a/roles/worker/tasks/main.yml
+++ b/roles/worker/tasks/main.yml
@@ -114,6 +114,6 @@
 - name: compute restart control vars
   set_fact:
     service_pod_restart: >
-      {{ (environment|changed or worker_pulls|changed or worker_units|changed) and not (worker_service_results|changed) }}
+      {{ (environment|changed or worker_pulls|changed or worker_units|changed) and not worker_service_results|changed }}
     logstash_forwarder_restart: >
-      {{ (lf_binary|changed or lf_config|changed or lf_unit|changed) and not (lf_service_result|changed) }}
+      {{ (lf_binary|changed or lf_config|changed or lf_unit|changed) and not lf_service_result|changed }}


### PR DESCRIPTION
Without this, every `script/deploy` run triggers the restarts.
