### PR TITLE
pod_names is a variable

### DIFF
--- a/restart.yml
+++ b/restart.yml
@@ -19,16 +19,14 @@
   # Instead, manually restart each pod together by invoking systemctl directly.
   - name: restart service pods
     command: systemctl restart deconst-content@{{ item }}.service deconst-presenter@{{ item }}.service
-    with_items:
-    - pod_names
+    with_items: pod_names
     when: service_pod_restart|default(false)|bool
     sudo: yes
     tags: restart
 
   - name: restart presenters only
     command: systemctl restart deconst-presenter@{{ item }}.service
-    with_items:
-    - pod_names
+    with_items: pod_names
     when: presenter_restart|default(false)|bool
     sudo: yes
     tags: restart

--- a/roles/worker/tasks/main.yml
+++ b/roles/worker/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: pod name ranges
   set_fact:
     pod_names: "[{% for i in range(1, pod_count + 1) %}{{ i }}{% if not loop.last %},{% endif %}{% endfor %}]"
+  tags: always
 
 - name: environment variables
   template:


### PR DESCRIPTION
Oops.

```
$ script/status
deconst-drc-worker-green-001 | success | rc=0 >>
...               
f22c38efea99        quay.io/deconst/presenter:latest         "npm start"         3 minutes ago       Up 3 minutes        0.0.0.0:32828->8080/tcp   presenter-pod_names         
45681ce9925f        quay.io/deconst/content-service:latest   "npm start"         6 minutes ago       Up 6 minutes        0.0.0.0:32826->8080/tcp   content-service-pod_names  
```
