### PR TITLE
Limit script/ssh matching to the current instance's host.

### DIFF
--- a/script/ssh
+++ b/script/ssh
@@ -6,7 +6,7 @@ import re
 import os
 import sys
 
-if len(sys.argv) > 3:
+if len(sys.argv) > 2:
     print "Usage: {} <hostname>".format(sys.argv[0])
     sys.exit(1)
 

--- a/script/ssh
+++ b/script/ssh
@@ -6,11 +6,9 @@ import re
 import os
 import sys
 
-if len(sys.argv) != 2:
+if len(sys.argv) > 3:
     print "Usage: {} <hostname>".format(sys.argv[0])
     sys.exit(1)
-
-hostname = sys.argv[1]
 
 # Get our bearings on the filesystem.
 root = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
@@ -21,6 +19,7 @@ with open(os.path.join(root, "credentials.yml")) as credfile:
 rackspace_username = creds["rackspace_username"]
 rackspace_apikey = creds["rackspace_api_key"]
 rackspace_region = creds["rackspace_region"]
+instance = creds["instance"]
 admin_apikey = re.sub(r'\s+', "", creds["content_admin_apikey"])
 
 pyrax.set_setting("identity_type", "rackspace")
@@ -28,16 +27,46 @@ pyrax.set_setting("region", rackspace_region)
 pyrax.set_credentials(rackspace_username, rackspace_apikey)
 cs = pyrax.cloudservers
 
-the_server = None
-for server in cs.servers.list():
-    if hostname in server.name:
-        if not the_server:
-            the_server = server
-        else:
-            raise Exception("More than one server with that name found.")
+all_servers = cs.servers.list()
 
-if not the_server:
-    raise Exception("No servers with that name found.")
+instance_pattern = "deconst-{}".format(instance)
+instance_servers = [server for server in all_servers
+    if server.name.startswith(instance_pattern)]
+
+if len(sys.argv) != 2:
+    print "Usage: {} <hostname>".format(sys.argv[0])
+    print
+    print "Available servers:"
+    for server in instance_servers:
+        print "  {}".format(server.name)
+    sys.exit(0)
+
+hostname = sys.argv[1]
+
+the_server = None
+matching_servers = []
+for server in instance_servers:
+    if hostname in server.name:
+        matching_servers.append(server)
+
+if not matching_servers:
+    print "No servers found that match that name."
+    print
+    print "These are the servers that are available:"
+    for server in instance_servers:
+        print("  {}".format(server.name))
+    sys.exit(1)
+
+if len(matching_servers) > 1:
+    print "More than one server matched that name! Please provide a more"
+    print "specific query."
+    print
+    print "These are the matches:"
+    for server in matching_servers:
+        print("  {}".format(server.name))
+    sys.exit(1)
+
+the_server = matching_servers[0]
 
 address = the_server.accessIPv4
 


### PR DESCRIPTION
Also, print more informative failure messages if the host match fails.
