### PR TITLE
Use a build of systemd-docker with a bumped client API version

### DIFF
--- a/roles/common/tasks/prereqs.yml
+++ b/roles/common/tasks/prereqs.yml
@@ -17,7 +17,7 @@
   pip: name=docker-py state=present version=1.1.0
 
 - name: systemd-docker binary
-  get_url: dest=/opt/bin/systemd-docker url=https://github.com/ibuildthecloud/systemd-docker/releases/download/v0.2.0/systemd-docker
+  get_url: dest=/opt/bin/systemd-docker force=yes url=https://9616cfffc9f266c74f07-b0b61db18139e69b9a725d06797c5b61.ssl.cf5.rackcdn.com/systemd-docker-f894d629146c3fd97ba5de77053a08671951d626ca9f0238f1463d90e9465703
   sudo: yes
 
 - name: systemd-docker is executable


### PR DESCRIPTION
I'm now hosting a build of systemd-docker from ibuildthecloud/systemd-docker#34 to deal with the Docker API mismatch.
