### PR TITLE
Make the control repo read/write

### DIFF
--- a/roles/worker/files/services/deconst-presenter@.service
+++ b/roles/worker/files/services/deconst-presenter@.service
@@ -20,7 +20,7 @@ ExecStart=/opt/bin/systemd-docker run \
   --env=PRESENTER_LOG_LEVEL=${PRESENTER_LOG_LEVEL} \
   --env=PRESENTER_LOG_COLOR=false \
   --env=NODE_ENV=${NODE_ENV} \
-  --volume=/var/deconst/control:/var/deconst/control:ro \
+  --volume=/var/deconst/control:/var/deconst/control \
   --publish=0.0.0.0::8080 \
   quay.io/deconst/presenter
 


### PR DESCRIPTION
Because the presenter needs to be able to `npm install` dependencies for plugins within the control repo, the control repo volume needs to be mounted read/write instead of read-only.

Thanks @ktbartholomew for doing all the actual work on this one :wink:
