### PR TITLE
Persist authorized SSH keys across cluster restarts

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -12,9 +12,11 @@ instance:
 # downtime.
 deployment: blue
 
-# Make this an array of GitHub usernames to install these users' public SSH keys on all provisioned
-# hosts, granting them access.
-github_usernames: []
+# Make this an array of administrators' public keys to install on all provisioned hosts, granting them access to the "core" user.
+admin_ssh_pubkeys:
+# - name: someone
+#   pubkey: >
+#    ssh-rsa AAAAB3Nz...
 
 # Name and URL of the GitHub repository containing the site mapping and layouts.
 #

--- a/roles/common/tasks/ssh.yml
+++ b/roles/common/tasks/ssh.yml
@@ -13,7 +13,7 @@
     regexp: "^github\\.com"
   sudo: yes
 
-- name: trust GitHub users
-  authorized_key: user=core state=present key=https://github.com/{{ item }}.keys
-  with_items: github_usernames
+- name: trust administrator ssh keys
+  shell: echo '{{ item.pubkey }}' | update-ssh-keys -a {{ item.name }}
+  with_items: admin_ssh_pubkeys
   tags: keys


### PR DESCRIPTION
CoreOS uses a script called `update-ssh-keys` to manage trusted SSH public keys. If you edit `~/.ssh/authorized_keys` directly, every system restart will wipe out that file and replace it with a newly generated one based on the `update-ssh-keys` configuration.

Rather than using Ansible's SSH key management module, shell out to `update-ssh-keys` to make changes sticky.

Fixes deconst/deconst-docs#160. Will require a `credentials.yml` change once I roll this out to other environments.
