### PR TITLE
Guard against credentials being out of sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ To deploy or update a cluster:
 
 ### Parameters
 
+Deconst guards against inconsistent `credentials.yml` files being run by multiple maintainers. If you intentionally make changes to the credentials file, you'll need to provide extra variables to `script/deploy`.
+
+If you change the `deployment`, run with:
+
+```bash
+script/deploy -e 'new_deployment=true'
+```
+
+If you make any other local changes to a `credentials.yml` file, run with:
+
+```bash
+script/deploy -e 'credentials_update=true'
+```
+
 To only update the control repository's content map, layout map or templates:
 
 ```bash

--- a/common.yml
+++ b/common.yml
@@ -9,6 +9,8 @@
   roles:
   - defunctzombie.coreos-bootstrap
 
+- include: verify.yml
+
 - hosts: deconst-all
   vars_files:
   - vars.yml

--- a/script/deploy
+++ b/script/deploy
@@ -7,6 +7,23 @@ ROOT=$(cd $(dirname $0)/.. && pwd)
 source ${ROOT}/script/include/credentials.sh
 source ${ROOT}/script/include/setup.sh
 
+# Avoid provisioning new deployments unless explicitly requested to do so.
+if ! ${ROOT}/script/include/is-existing-cluster 2>/dev/null; then
+  if echo "$@" | grep -q 'new_deployment=true'; then
+    echo "This is a new deployment."
+  else
+    cat <<EOM >&2
+It looks like you're trying to provision a new deployment.
+If this is what you really mean to do, add this argument:
+
+  -e 'new_deployment=true'
+
+Otherwise, it's likely that you need to update your credentials.yml file.
+EOM
+    exit 1
+  fi
+fi
+
 setup_inventory
 setup_galaxy
 

--- a/script/include/is-existing-cluster
+++ b/script/include/is-existing-cluster
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import pyrax
+import yaml
+import os
+import sys
+import subprocess
+import re
+
+# Get our bearings on the filesystem.
+root = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# Collect credentials.
+with open(os.path.join(root, "credentials.yml")) as credfile:
+    creds = yaml.load(credfile)
+rackspace_username = creds["rackspace_username"]
+rackspace_apikey = creds["rackspace_api_key"]
+rackspace_region = creds["rackspace_region"]
+instance = creds["instance"]
+deployment = creds["deployment"]
+
+pyrax.set_setting("identity_type", "rackspace")
+pyrax.set_credentials(rackspace_username, rackspace_apikey)
+cs = pyrax.connect_to_cloudservers(region=rackspace_region)
+
+pattern = "deconst-{}".format(instance)
+all_servers = cs.servers.list()
+
+matching_servers = []
+for server in all_servers:
+    group = server.metadata.get('group')
+    if not group or not group.startswith(pattern):
+        continue
+
+    parts = group.split("-")
+    if parts[-1] != deployment:
+        continue
+
+    # At least one matching host exists
+    sys.exit(0)
+
+# No matching hosts
+sys.exit(1)

--- a/verify.yml
+++ b/verify.yml
@@ -1,0 +1,46 @@
+---
+# Verify that your version of credentials.yml is up to date, unless you're explicitly messing
+# with it.
+
+- name: checksum
+  hosts: local
+  connection: local
+  tasks:
+
+  - name: checksum your credentials.yml
+    command: shasum -a 256 credentials.yml
+    register: credentials_sha256
+    changed_when: no
+    tags: verify
+
+- name: verify
+  hosts: deconst-all
+  tasks:
+
+  - name: read an already-present credentials.sha256 file
+    command: cat ~/credentials.sha256
+    register: existing_credentials_sha256
+    ignore_errors: yes
+    changed_when: no
+    tags: verify
+
+  - name: ensure that the credentials file matches
+    fail:
+      msg: >
+        It looks like your local credentials.yml file differs from the last one that was used
+        against this cluster. If you have intentional local edits, re-run script/deploy with
+        this argument:
+
+          -e 'credentials_update=true'
+
+        Otherwise, please obtain the latest version of credentials.yml for this cluster and try
+        again.
+    when: >
+      hostvars.localhost.credentials_sha256.stdout != existing_credentials_sha256.stdout
+      and not credentials_update|default(false)
+    tags: verify
+
+  - name: record the new credentials SHA
+    shell: echo -n "{{ hostvars.localhost.credentials_sha256.stdout }}" > ~/credentials.sha256
+    changed_when: no
+    tags: verify


### PR DESCRIPTION
When multiple people are doing ops on the same Deconst cluster, there's a danger of everyone's `credentials.yml` files getting out of sync. I'd like to introduce some simple guards against this.
- [x] If no existing hosts match the instance name and current deployment, fail out of `script/deploy` before invoking Ansible. Opt in with `-e 'new_deployment=true'`.
- [x] Store a sha256 of the `credentials.yml` file on each host. Before doing anything significant, test the sha of the local file against the stored one. Only update the sha and continue if `-e credentials_update=true` has been set.
