### PR TITLE
Don't bounce the Docker daemon when firewall rules change

### DIFF
--- a/roles/common/tasks/firewall.yml
+++ b/roles/common/tasks/firewall.yml
@@ -8,13 +8,3 @@
 - name: enable the iptables service
   service: name=iptables-restore.service enabled=yes
   sudo: yes
-
-- name: invoke the iptables service
-  service: name=iptables-restore.service state=started
-  when: firewall_rules | changed
-  sudo: yes
-
-- name: restart the docker daemon to reapply its iptables rules
-  service: name=docker.service state=restarted
-  when: firewall_rules | changed
-  sudo: yes

--- a/script/allow-ssh
+++ b/script/allow-ssh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -ueo pipefail
+
+ROOT=$(cd $(dirname $0)/.. && pwd)
+
+ADDR=${1:-}
+
+[ -n "${ADDR}" ] || {
+  echo "Usage: ${0} <ip addr>" >&2
+  exit 1
+}
+
+${ROOT}/script/ansible -s \
+  -m shell \
+  -a "iptables -A INPUT -i eth0 -p tcp -m tcp --source ${ADDR} --dport 22 -j ACCEPT"
+
+echo
+echo "Remember to also add ${ADDR} to ${ROOT}/roles/common/templates/rules-save.j2"


### PR DESCRIPTION
Docker's networking works by manipulating iptables rules, so technically, to have iptables rules changes take effect, you need to:
- Stop the docker daemon on that host.
- Run the iptables-restore service to wipe iptables' state and start fresh with our base rules.
- Start the docker daemon again.

The problem is that I basically _never_ want to do this across the entire cluster, because it leads to service thrashing; all of the services try to deregister and reregister themselves on their load balancers at once and chaos ensues.

For now, let's use some simple scripts to manipulate the iptables state in situ instead, and only use the templated `rules-save.j2` file to ensure that changes persist across reboots.
