### PR TITLE
Minor fixes discovered during deconst-docs deployment.

### DIFF
--- a/roles/build/templates/deconst-strider-environment.j2
+++ b/roles/build/templates/deconst-strider-environment.j2
@@ -37,7 +37,7 @@ PLUGIN_GITHUB_ADMIN_TEAM={{ strider_admin_team }}
 
 # Strider settings
 
-SERVER_NAME=http://{{ build_domain }}
+SERVER_NAME=https://{{ build_domain }}
 STRIDER_SYSTEM_EMAIL={{ strider_system_email }}
 STRIDER_WORKSPACE_CONTAINER=deconst-strider-workspace
 

--- a/roles/common/templates/rules-save.j2
+++ b/roles/common/templates/rules-save.j2
@@ -43,7 +43,7 @@
 
 {% if inventory_hostname in groups['deconst-elastic'] %}
 # Accept logstash logs over ServiceNet
-{% for host in groups['deconst-worker']|sort %}
+{% for host in groups['deconst-all']|sort %}
 -A DOCKER -i eth1 -p tcp --source {{ hostvars[host].ansible_eth1.ipv4.address }} --dport 5000 -j ACCEPT
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Nothing big this time, shockingly. Although I will note that `strider_access_team` and
`strider_admin_team` are omitted by being left blank, not by being deleted.
