### PR TITLE
Configure DNS servers explicitly

### DIFF
--- a/roles/common/files/resolved.conf
+++ b/roles/common/files/resolved.conf
@@ -1,0 +1,5 @@
+# See resolved.conf(5) for details
+
+[Resolve]
+DNS=8.8.8.8
+FallbackDNS=8.8.4.4

--- a/roles/common/tasks/prereqs.yml
+++ b/roles/common/tasks/prereqs.yml
@@ -1,5 +1,20 @@
 ---
 
+- name: dns servers
+  copy:
+    dest: /etc/systemd/resolved.conf
+    src: resolved.conf
+    owner: root
+    group: root
+    mode: 0644
+  register: dns_configuration
+  sudo: yes
+
+- name: kick systemd-resolved
+  service: name=systemd-resolved state=restarted
+  when: dns_configuration | changed
+  sudo: yes
+
 - name: necessary directories
   file:
     path: "{{ item }}"


### PR DESCRIPTION
Configure systemd-resolved to use Google's DNS servers. This mitigates an issue where we had CoreOS hosts drop DHCP-acquired DNS settings.
