### PR TITLE
Parameterize server images as well

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -51,6 +51,9 @@ worker_count: 3
 # Rackspace server flavor to use for worker hosts.
 worker_flavor: general1-2
 
+# Rackspace server image to use for worker hosts.
+worker_image: "{{ image_coreos_beta }}"
+
 # Number of "pods" of related services to launch on each worker host.
 pod_count: 2
 
@@ -60,11 +63,17 @@ elastic_count: 1
 # Rackspace server flavor to use for elasticsearch hosts.
 elastic_flavor: general1-2
 
+# Rackspace server image to use for worker hosts.
+elastic_image: "{{ image_coreos_beta }}"
+
 # Number of servers to include in the build cluster.
 build_count: 1
 
 # Rackspace server flavor to use for build hosts.
 build_flavor: general1-2
+
+# Rackspace server flavor to use for build hosts.
+build_image: "{{ image_coreos_beta }}"
 
 # Number of builds to support in parallel at once.
 build_parallel_jobs: 2
@@ -74,6 +83,9 @@ staging_count: 1
 
 # Rackspace server flavor to use for staging hosts.
 staging_flavor: general1-2
+
+# Rackspace server flavor to use for staging hosts.
+staging_image: "{{ image_coreos_beta }}"
 
 # Number of "pods" to launch on each staging host.
 staging_pod_count: 2

--- a/provision.yml
+++ b/provision.yml
@@ -17,7 +17,7 @@
       group: deconst-{{ instance }}-worker-{{ deployment }}
       count: "{{ worker_count }}"
       exact_count: yes
-      image: "{{ image_coreos_beta }}"
+      image: "{{ worker_image }}"
       flavor: "{{ worker_flavor }}"
       key_name: "{{ rackspace_keyname }}"
       wait: yes
@@ -53,7 +53,7 @@
       group: deconst-{{ instance }}-elastic-{{ deployment }}
       count: "{{ elastic_count }}"
       exact_count: yes
-      image: "{{ image_coreos_beta }}"
+      image: "{{ elastic_image }}"
       flavor: "{{ elastic_flavor }}"
       key_name: "{{ rackspace_keyname }}"
       wait: yes
@@ -90,7 +90,7 @@
       group: deconst-{{ instance }}-build-{{ deployment }}
       count: "{{ build_count }}"
       exact_count: yes
-      image: "{{ image_coreos_beta }}"
+      image: "{{ build_image }}"
       flavor: "{{ build_flavor }}"
       key_name: "{{ rackspace_keyname }}"
       wait: yes
@@ -127,7 +127,7 @@
       group: deconst-{{ instance }}-staging-{{ deployment }}
       count: "{{ staging_count }}"
       exact_count: yes
-      image: "{{ image_coreos_beta }}"
+      image: "{{ staging_image }}"
       flavor: "{{ staging_flavor }}"
       key_name: "{{ rackspace_keyname }}"
       wait: yes


### PR DESCRIPTION
Server images in `provision.yml` were all using a static image from `vars.yml`. To be able to move the build host to OnMetal, I need to be able to override the server image on a per-instance basis.
